### PR TITLE
Remove dynamic var from dev ns.

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,26 +1,23 @@
- (ns user
-   (:require [reloaded.repl :refer [set-init! system init start stop go reset reset-all]]
-             [arachne.core :as a]
-             [arachne.figwheel :as fig]
-             [org.arachne-framework.template.enterprise-spa :as app])
-   )
-
-(def ^{:dynamic true
-       :doc "Bound to the config for the current application"}
-  *cfg*
-  nil)
+(ns user
+  (:require [reloaded.repl :refer [set-init! system init start stop go reset reset-all]]
+            [arachne.core :as a]
+            [arachne.figwheel :as fig]
+            [org.arachne-framework.template.enterprise-spa :as app]))
 
 (defn init-arachne
   "Create an Arachne runtime"
   [runtime]
-  (let [cfg (a/config :org.arachne-framework.template/enterprise-spa)
-        rt (a/runtime cfg runtime)]
-    (alter-var-root #'*cfg* (constantly cfg))
-    rt))
+  (a/runtime (a/config :org.arachne-framework.template/enterprise-spa)
+             runtime))
 
 (set-init! #(init-arachne ::app/runtime))
 
 (defn cljs-repl
-  "Launch a CLJS repl for a Figwheel in the currently running Arachne system"
+  "Launch a CLJS repl for a Figwheel in the currently running Arachne system."
   []
   (fig/repl system))
+
+(defn config
+  "Returns the config for the currently running Arachne system."
+  []
+  (:config system))


### PR DESCRIPTION
There's no need for the `*cfg*` dynamic var since the running system's config is available in the `system` map.