### PR TITLE
Remove :output-dir option of sass/build

### DIFF
--- a/config/org/arachne_framework/template/enterprise_spa.clj
+++ b/config/org/arachne_framework/template/enterprise_spa.clj
@@ -46,8 +46,7 @@
 
 (a/id ::sass-build
   (sass/build {:entrypoint "app.scss"
-               :output-to "app.css"
-               :output-dir "css"
+               :output-to "css/app.css"
                :source-map (dev?)
                :precision 6}))
 


### PR DESCRIPTION
This updates the template to use the new arachne-sass module's options (i.e. without the :output-dir option)